### PR TITLE
Add a query service and controller for USGS earthquake data around Storke. 🔔

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12827,36 +12827,6 @@
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
       "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA=="
     },
-    "node_modules/babel-eslint": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
-      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
-      "deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.0",
-        "@babel/traverse": "^7.7.0",
-        "@babel/types": "^7.7.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "resolve": "^1.12.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "eslint": ">= 4.12.1"
-      }
-    },
-    "node_modules/babel-eslint/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/babel-jest": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.5.1.tgz",
@@ -44569,27 +44539,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
       "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA=="
-    },
-    "babel-eslint": {
-      "version": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
-      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.0",
-        "@babel/traverse": "^7.7.0",
-        "@babel/types": "^7.7.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "resolve": "^1.12.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-          "dev": true
-        }
-      }
     },
     "babel-jest": {
       "version": "27.5.1",

--- a/src/main/java/edu/ucsb/cs156/example/collections/EarthquakesCollection.java
+++ b/src/main/java/edu/ucsb/cs156/example/collections/EarthquakesCollection.java
@@ -4,7 +4,7 @@ import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
-import edu.ucsb.cs156.example.documents.Features;
+import edu.ucsb.cs156.example.documents.Feature;
 
 @Repository
-public interface EarthquakesCollection extends MongoRepository<Features, ObjectId> { }
+public interface EarthquakesCollection extends MongoRepository<Feature, ObjectId> { }

--- a/src/main/java/edu/ucsb/cs156/example/collections/EarthquakesCollection.java
+++ b/src/main/java/edu/ucsb/cs156/example/collections/EarthquakesCollection.java
@@ -1,0 +1,10 @@
+package edu.ucsb.cs156.example.collections;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import edu.ucsb.cs156.example.documents.Features;
+
+@Repository
+public interface EarthquakesCollection extends MongoRepository<Features, ObjectId> { }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/EarthquakesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/EarthquakesController.java
@@ -54,8 +54,12 @@ public class EarthquakesController extends ApiController
     ) throws JsonProcessingException {
         // TODO: Remove this log message.
         log.info("upsert with parameters magnitude={}, distance={}", magnitude, distance);
+
         Features features = querier.getJSON(distance, magnitude);
         Features saved = earthquakes.save(features);
+
+        // TODO: How does ResponseEntity know how to convert a Features into a body? 🤯
+        // All of the magic is driving me nuts!
         return ResponseEntity.ok().body(saved);
     }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/EarthquakesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/EarthquakesController.java
@@ -60,7 +60,7 @@ public class EarthquakesController extends ApiController
     @PostMapping("/retrieve")
     @ApiOperation(value = "Store recent earthquakes.", notes = "Delegate to the query service from team01. Only accessible to administrators. Beware duplicates.")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    public Features upsert(
+    public Iterable<Feature> upsert(
         // Why are these parameters strings? I don't understand why the querier mandates that.
         @ApiParam("Minimum magnitude.") @RequestParam String magnitude,
         @ApiParam("Distance from Storke.") @RequestParam String distance
@@ -73,6 +73,6 @@ public class EarthquakesController extends ApiController
         // serialized object — how?! — in the body of the response? Sure, why
         // not.
 
-        return features;
+        return features.getFeatures();
     }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/EarthquakesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/EarthquakesController.java
@@ -1,0 +1,61 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.collections.EarthquakesCollection;
+import edu.ucsb.cs156.example.documents.Features;
+import edu.ucsb.cs156.example.services.EarthquakeQueryService;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@Api(description = "Information about recent earthquakes.")
+@RequestMapping("/api/earthquakes")
+public class EarthquakesController extends ApiController
+{
+    @Autowired
+    EarthquakesCollection earthquakes;
+
+    @Autowired
+    EarthquakeQueryService querier;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @GetMapping("/all")
+    @ApiOperation(value = "List all earthquakes.")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    public Iterable<Features> getAll() {
+        return earthquakes.findAll();
+    }
+
+    @PostMapping("/upsert")
+    @ApiOperation(value = "Store recent earthquakes.", notes = "Delegate to the query service from team01.")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    public ResponseEntity<Features> upsert(
+        // Why are these parameters strings? I don't understand why the querier mandates that.
+        @ApiParam("Minimum magnitude.") @RequestParam String magnitude,
+        @ApiParam("Distance from Storke.") @RequestParam String distance
+    ) throws JsonProcessingException {
+        // TODO: Remove this log message.
+        log.info("upsert with parameters magnitude={}, distance={}", magnitude, distance);
+        Features features = querier.getJSON(distance, magnitude);
+        Features saved = earthquakes.save(features);
+        return ResponseEntity.ok().body(saved);
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/EarthquakesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/EarthquakesController.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -57,7 +58,7 @@ public class EarthquakesController extends ApiController
     }
 
     @PostMapping("/retrieve")
-    @ApiOperation(value = "Store recent earthquakes.", notes = "Delegate to the query service from team01.")
+    @ApiOperation(value = "Store recent earthquakes.", notes = "Delegate to the query service from team01. Only accessible to administrators. Beware duplicates.")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     public Features upsert(
         // Why are these parameters strings? I don't understand why the querier mandates that.

--- a/src/main/java/edu/ucsb/cs156/example/documents/Feature.java
+++ b/src/main/java/edu/ucsb/cs156/example/documents/Feature.java
@@ -1,10 +1,13 @@
 package edu.ucsb.cs156.example.documents;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Feature
 {
     private String type;

--- a/src/main/java/edu/ucsb/cs156/example/documents/Feature.java
+++ b/src/main/java/edu/ucsb/cs156/example/documents/Feature.java
@@ -1,0 +1,13 @@
+package edu.ucsb.cs156.example.documents;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class Feature
+{
+    private String type;
+    private Properties properties;
+    private String id;
+}

--- a/src/main/java/edu/ucsb/cs156/example/documents/Feature.java
+++ b/src/main/java/edu/ucsb/cs156/example/documents/Feature.java
@@ -5,11 +5,20 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
 @Data
 @NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Document(collection = "earthquakes")
 public class Feature
 {
+    // This identifier is used by 🥭 to uniquely identify a document.
+
+    @Id
+    private String _id;
+
     private String type;
     private Properties properties;
     private String id;

--- a/src/main/java/edu/ucsb/cs156/example/documents/Features.java
+++ b/src/main/java/edu/ucsb/cs156/example/documents/Features.java
@@ -1,0 +1,24 @@
+package edu.ucsb.cs156.example.documents;
+
+import java.util.List;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Data
+@NoArgsConstructor
+@Document(collection = "features")
+public class Features
+{
+    // This identifier is used by 🥭 to uniquely identify a document.
+
+    @Id
+    private String _id;
+
+    private String type;
+    private Metadata metadata;
+    private List<Feature> features;
+}

--- a/src/main/java/edu/ucsb/cs156/example/documents/Features.java
+++ b/src/main/java/edu/ucsb/cs156/example/documents/Features.java
@@ -7,20 +7,11 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import org.springframework.data.annotation.Id;
-import org.springframework.data.mongodb.core.mapping.Document;
-
 @Data
 @NoArgsConstructor
-@Document(collection = "features")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Features
 {
-    // This identifier is used by 🥭 to uniquely identify a document.
-
-    @Id
-    private String _id;
-
     private String type;
     private Metadata metadata;
     private List<Feature> features;

--- a/src/main/java/edu/ucsb/cs156/example/documents/Features.java
+++ b/src/main/java/edu/ucsb/cs156/example/documents/Features.java
@@ -14,5 +14,5 @@ public class Features
 {
     private String type;
     private Metadata metadata;
-    private List<Feature> features;
+    private Iterable<Feature> features;
 }

--- a/src/main/java/edu/ucsb/cs156/example/documents/Features.java
+++ b/src/main/java/edu/ucsb/cs156/example/documents/Features.java
@@ -2,6 +2,8 @@ package edu.ucsb.cs156.example.documents;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -11,6 +13,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Data
 @NoArgsConstructor
 @Document(collection = "features")
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Features
 {
     // This identifier is used by 🥭 to uniquely identify a document.

--- a/src/main/java/edu/ucsb/cs156/example/documents/Metadata.java
+++ b/src/main/java/edu/ucsb/cs156/example/documents/Metadata.java
@@ -1,10 +1,13 @@
 package edu.ucsb.cs156.example.documents;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Metadata
 {
     private String generated;

--- a/src/main/java/edu/ucsb/cs156/example/documents/Metadata.java
+++ b/src/main/java/edu/ucsb/cs156/example/documents/Metadata.java
@@ -1,0 +1,16 @@
+package edu.ucsb.cs156.example.documents;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class Metadata
+{
+    private String generated;
+    private String url;
+    private String title;
+    private String status;
+    private String api;
+    private int count;
+}

--- a/src/main/java/edu/ucsb/cs156/example/documents/Properties.java
+++ b/src/main/java/edu/ucsb/cs156/example/documents/Properties.java
@@ -1,0 +1,36 @@
+package edu.ucsb.cs156.example.documents;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class Properties
+{
+    // According to #25, we are interested in displaying only the title,
+    // magnitute, place, and time.
+
+    // https://github.com/ucsb-cs156-w22/team03-w22-6pm-4/issues/25
+
+    /*
+    "mag": 2.64,
+    "place": "10km NW of Santa Paula, CA",
+    "time": 1644539746380,
+    ...
+    "title": "M 2.6 - 10km NW of Santa Paula, CA"
+    */
+
+    // I don't want to store the `time` field in a Long because it may overflow.
+    // Will convert it to a String. Is this going to cause a problem when
+    // Jackson — not me, the library — tries to stuff a JSON object with a
+    // JSON value of type number in it?
+
+    // https://www.json.org/json-en.html
+
+    // I don't know how comfortable Jackson is with type conversions!
+
+    private Double mag;
+    private String place;
+    private String time;
+    private String title;
+}

--- a/src/main/java/edu/ucsb/cs156/example/documents/Properties.java
+++ b/src/main/java/edu/ucsb/cs156/example/documents/Properties.java
@@ -1,10 +1,13 @@
 package edu.ucsb.cs156.example.documents;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Properties
 {
     // According to #25, we are interested in displaying only the title,
@@ -20,14 +23,15 @@ public class Properties
     "title": "M 2.6 - 10km NW of Santa Paula, CA"
     */
 
-    // I don't want to store the `time` field in a Long because it may overflow.
-    // Will convert it to a String. Is this going to cause a problem when
-    // Jackson — not me, the library — tries to stuff a JSON object with a
+    // TODO: I don't want to store the `time` field in a Long because it may
+    // overflow. Will convert it to a String. Is this going to cause a problem
+    // when Jackson — not me, the library — tries to stuff a JSON object with a
     // JSON value of type number in it?
 
-    // https://www.json.org/json-en.html
+    // Answer: No, Jackson — not me, the library — has no problem coercing the
+    // JSON data to the desired Java type, and will explode if it can't.
 
-    // I don't know how comfortable Jackson is with type conversions!
+    // https://www.json.org/json-en.html
 
     private Double mag;
     private String place;

--- a/src/main/java/edu/ucsb/cs156/example/services/EarthquakeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/example/services/EarthquakeQueryService.java
@@ -41,8 +41,8 @@ public class EarthquakeQueryService
 
         HttpEntity<String> entity = new HttpEntity<>(headers);
 
-        String ucsbLat = "34.4140"; // hard coded params for Storke Tower
-        String ucsbLong = "-119.8489";
+        String ucsbLat = "34.4140";    // Storke. 🔔
+        String ucsbLong = "-119.8489"; // <-
         Map<String, String> uriVariables = Map.of("minMag", minMag, "distance", distance, "latitude", ucsbLat, "longitude", ucsbLong);
 
         ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class, uriVariables);

--- a/src/main/java/edu/ucsb/cs156/example/services/EarthquakeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/example/services/EarthquakeQueryService.java
@@ -35,7 +35,6 @@ public class EarthquakeQueryService
     public static final String ENDPOINT = "https://earthquake.usgs.gov/fdsnws/event/1/query?format=geojson&minmagnitude={minMag}&maxradiuskm={distance}&latitude={latitude}&longitude={longitude}";
 
     public Features getJSON(String distance, String minMag) throws HttpClientErrorException, JsonProcessingException {
-        log.info("distance={}, minMag={}", distance, minMag);
         HttpHeaders headers = new HttpHeaders();
         headers.setAccept(List.of(MediaType.APPLICATION_JSON));
         headers.setContentType(MediaType.APPLICATION_JSON);
@@ -48,7 +47,7 @@ public class EarthquakeQueryService
 
         ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class, uriVariables);
 
-        // Modifications follow.
+        // TODO: Modifications to the querier follow. Are they okay?
 
         String json = re.getBody();
 

--- a/src/main/java/edu/ucsb/cs156/example/services/EarthquakeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/example/services/EarthquakeQueryService.java
@@ -1,0 +1,52 @@
+package edu.ucsb.cs156.example.services;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.web.client.RestTemplate;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+
+@Slf4j
+@Service
+public class EarthquakeQueryService
+{
+    ObjectMapper mapper = new ObjectMapper();
+
+    private final RestTemplate restTemplate;
+
+    public EarthquakeQueryService(RestTemplateBuilder restTemplateBuilder) {
+        restTemplate = restTemplateBuilder.build();
+    }
+
+    public static final String ENDPOINT = "https://earthquake.usgs.gov/fdsnws/event/1/query?format=geojson&minmagnitude={minMag}&maxradiuskm={distance}&latitude={latitude}&longitude={longitude}";
+
+    public String getJSON(String distance, String minMag) throws HttpClientErrorException {
+        log.info("distance={}, minMag={}", distance, minMag);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        String ucsbLat = "34.4140"; // hard coded params for Storke Tower
+        String ucsbLong = "-119.8489";
+        Map<String, String> uriVariables = Map.of("minMag", minMag, "distance", distance, "latitude", ucsbLat,
+                "longitude", ucsbLong);
+
+        ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,
+                uriVariables);
+        return re.getBody();
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/EarthquakesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/EarthquakesControllerTests.java
@@ -1,0 +1,90 @@
+package edu.ucsb.cs156.example.controllers;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import edu.ucsb.cs156.example.collections.EarthquakesCollection;
+import edu.ucsb.cs156.example.controllers.EarthquakesController;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.services.EarthquakeQueryService;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+
+@WebMvcTest(controllers = EarthquakesController.class)
+@Import(TestConfig.class)
+public class EarthquakesControllerTests extends ControllerTestCase
+{
+    @MockBean
+    UserRepository userRepository;
+
+    @MockBean
+    EarthquakesCollection earthquakes;
+
+    @MockBean
+    EarthquakeQueryService querier;
+
+    /* GET /api/earthquakes/all */
+
+    @Test
+    public void stranger_does_list() throws Exception
+    {
+        mockMvc.perform(get("/api/earthquakes/all"))
+            .andExpect(status().is(403));
+    }
+
+    /* POST /api/earthquakes/purge */
+
+    @Test
+    public void stranger_does_purge() throws Exception
+    {
+        mockMvc.perform(post("/api/earthquakes/purge"))
+            .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void user_does_purge() throws Exception
+    {
+        mockMvc.perform(post("/api/earthquakes/purge"))
+            .andExpect(status().is(403));
+    }
+
+    /* POST /api/earthquakes/retrieve */
+
+    @Test
+    public void stranger_does_retrieve() throws Exception
+    {
+        mockMvc.perform(post("/api/earthquakes/retrieve"))
+            .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void user_does_retrieve() throws Exception
+    {
+        mockMvc.perform(post("/api/earthquakes/retrieve"))
+            .andExpect(status().is(403));
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/example/services/EarthquakeQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/services/EarthquakeQueryServiceTests.java
@@ -1,0 +1,44 @@
+package edu.ucsb.cs156.example.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+
+@RestClientTest(EarthquakeQueryService.class)
+public class EarthquakeQueryServiceTests {
+
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Autowired
+    private EarthquakeQueryService earthquakeQueryService;
+
+    @Test
+    public void test_getJSON() {
+
+        String distance = "10";
+        String minMag = "1.5";
+        String ucsbLat = "34.4140"; // hard coded params for Storke Tower
+        String ucsbLong = "-119.8489";
+        String expectedURL = EarthquakeQueryService.ENDPOINT.replace("{distance}", distance)
+                .replace("{minMag}", minMag).replace("{latitude}", ucsbLat).replace("{longitude}", ucsbLong);
+
+        String fakeJsonResult = "{ \"fake\" : \"result\" }";
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
+
+        String actualResult = earthquakeQueryService.getJSON(distance, minMag);
+        assertEquals(fakeJsonResult, actualResult);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/example/services/EarthquakeQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/services/EarthquakeQueryServiceTests.java
@@ -1,5 +1,7 @@
 package edu.ucsb.cs156.example.services;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.http.MediaType;
@@ -12,36 +14,40 @@ import static org.springframework.test.web.client.match.MockRestRequestMatchers.
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
 
+import edu.ucsb.cs156.example.documents.Features;
+
 @RestClientTest(EarthquakeQueryService.class)
-public class EarthquakeQueryServiceTests {
+public class EarthquakeQueryServiceTests
+{
+    @Autowired
+    private MockRestServiceServer server;
 
     @Autowired
-    private MockRestServiceServer mockRestServiceServer;
-
-    @Autowired
-    private EarthquakeQueryService earthquakeQueryService;
-
-    /*
-    TODO: Querier needs to return a Features.
+    private EarthquakeQueryService querier;
 
     @Test
-    public void test_getJSON() {
+    public void test_getJSON() throws JsonProcessingException {
         String distance = "10";
         String minMag = "1.5";
-        String ucsbLat = "34.4140"; // hard coded params for Storke Tower
-        String ucsbLong = "-119.8489";
-        String expectedURL = EarthquakeQueryService.ENDPOINT.replace("{distance}", distance)
-                .replace("{minMag}", minMag).replace("{latitude}", ucsbLat).replace("{longitude}", ucsbLong);
+        String ucsbLat = "34.4140";    // Storke. 🔔
+        String ucsbLong = "-119.8489"; // <-
 
-        String fakeJsonResult = "{ \"fake\" : \"result\" }";
+        String expectedURL = EarthquakeQueryService.ENDPOINT
+            .replace("{distance}", distance)
+            .replace("{minMag}", minMag)
+            .replace("{latitude}", ucsbLat)
+            .replace("{longitude}", ucsbLong);
 
-        this.mockRestServiceServer.expect(requestTo(expectedURL))
-                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
-                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
-                .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
+        String someJSON = "{ \"type\": \"Not GeoJSON, sorry.\", \"metadata\": null, \"features\": null }";
+        Features someFeatures = new Features();
+        someFeatures.setType("Not GeoJSON, sorry.");
 
-        String actualResult = earthquakeQueryService.getJSON(distance, minMag);
-        assertEquals(fakeJsonResult, actualResult);
+        this.server.expect(requestTo(expectedURL))
+            .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+            .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+            .andRespond(withSuccess(someJSON, MediaType.APPLICATION_JSON));
+
+        Features actual = querier.getJSON(distance, minMag);
+        assertEquals(someFeatures, actual);
     }
-    */
 }

--- a/src/test/java/edu/ucsb/cs156/example/services/EarthquakeQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/services/EarthquakeQueryServiceTests.java
@@ -21,9 +21,11 @@ public class EarthquakeQueryServiceTests {
     @Autowired
     private EarthquakeQueryService earthquakeQueryService;
 
+    /*
+    TODO: Querier needs to return a Features.
+
     @Test
     public void test_getJSON() {
-
         String distance = "10";
         String minMag = "1.5";
         String ucsbLat = "34.4140"; // hard coded params for Storke Tower
@@ -41,4 +43,5 @@ public class EarthquakeQueryServiceTests {
         String actualResult = earthquakeQueryService.getJSON(distance, minMag);
         assertEquals(fakeJsonResult, actualResult);
     }
+    */
 }


### PR DESCRIPTION
Looking ahead:

- [ ] Every `Feature` object should have an associated `url` field with a value that looks similar to `https://earthquake.usgs.gov/earthquakes/eventpage/ci40182864`. In the front end, this will allow users to navigate to a USGS page for more information about the earthquake.

<img width="547" alt="endpoints" src="https://user-images.githubusercontent.com/24307788/154782194-64c26cbb-c1be-46cb-aa69-48fa09bb16e8.png">